### PR TITLE
Add spatial split evaluations and results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ cython_debug/
 # Miscellaneous
 .DS_Store
 data/external/*.xlsx
+results/raw/

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -13,7 +13,7 @@ BEAKER_CLUSTERS=...
 WEKA_BUCKET=...
 ```
 
-## Default
+## Default (random split)
 
 ### Pretrained weights
 
@@ -42,7 +42,38 @@ python -m experiment.beaker_finetune \
     --no-load-weights
 ```
 
-## Data ablations
+## Default (spatial split)
+
+### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial
+```
+
+### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --no-load-weights
+```
+
+## Data ablations (random split)
 
 ### All minus Sentinel-1
 
@@ -230,7 +261,207 @@ python -m experiment.beaker_finetune \
     --no-load-weights
 ```
 
-## Shape ablations
+## Data ablations (spatial split)
+
+### All minus Sentinel-1
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands S1
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands S1 \
+    --no-load-weights
+```
+
+### All minus Sentinel-2
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands S2_RGB S2_Red_Edge S2_NIR_10m S2_NIR_20m S2_SWIR NDVI
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands S2_RGB S2_Red_Edge S2_NIR_10m S2_NIR_20m S2_SWIR NDVI \
+    --no-load-weights
+```
+
+### All minus ERA5
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands ERA5
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands ERA5 \
+    --no-load-weights
+```
+
+### All minus TerraClimate
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands TC
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands TC \
+    --no-load-weights
+```
+
+### All minus SRTM
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands SRTM
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands SRTM \
+    --no-load-weights
+```
+
+### All minus location
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands location
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --excluded-bands location \
+    --no-load-weights
+```
+
+## Shape ablations (random split)
 
 ### output_hw=16, num_timesteps=12
 
@@ -401,7 +632,188 @@ python -m experiment.beaker_finetune \
     --no-load-weights
 ```
 
-### Spatial splits
+## Shape ablations (spatial split)
+
+### output_hw=16, num_timesteps=12
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 16 \
+    --num-timesteps 12
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 16 \
+    --num-timesteps 12 \
+    --no-load-weights
+```
+
+### output_hw=32, num_timesteps=6
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 32 \
+    --num-timesteps 6
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 32 \
+    --num-timesteps 6 \
+    --no-load-weights
+```
+
+### output_hw=32, num_timesteps=3
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 32 \
+    --num-timesteps 3
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 32 \
+    --num-timesteps 3 \
+    --no-load-weights
+```
+
+### output_hw=1, patch_size=1, num_timesteps=12
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 1 \
+    --patch-size 1 \
+    --num-timesteps 12
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 1 \
+    --patch-size 1 \
+    --num-timesteps 12 \
+    --no-load-weights
+```
+
+### output_hw=8, patch_size=8, num_timesteps=12
+
+#### Pretrained weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 8 \
+    --patch-size 8 \
+    --num-timesteps 12
+```
+
+#### Random weights
+
+```shell
+python -m experiment.beaker_finetune \
+    --image-name ${USER}/lfmc \
+    --priority high \
+    --gpu-count 1 \
+    --model-name tiny \
+    --data-folder /presto/data/lfmc/training_tifs \
+    --h5py-folder /presto/data/lfmc/h5pys \
+    --h5pys-only \
+    --split-type spatial \
+    --output-hw 8 \
+    --patch-size 8 \
+    --num-timesteps 12 \
+    --no-load-weights
+```
+
+### State-region holdout
 
 #### Pretrained weights
 
@@ -418,7 +830,7 @@ python -m experiment.beaker_finetune \
     --test-state-regions Texas Michigan
 ```
 
-#### Pretrained weights
+#### Random weights
 
 ```shell
 python -m experiment.beaker_finetune \

--- a/experiment/beaker_all_experiments.py
+++ b/experiment/beaker_all_experiments.py
@@ -1,0 +1,181 @@
+"""Launch all paper experiments on Beaker (both random and spatial splits)."""
+
+import argparse
+import signal
+import time
+from pathlib import Path
+
+from beaker import Beaker
+
+from lfmc.core.splits import SplitType
+
+from .beaker_args import BeakerArgs, add_common_beaker_args, get_beaker_args
+from .beaker_finetune import launch_experiment
+
+SHAPE_ABLATIONS = [
+    {"output_hw": 16, "num_timesteps": 12, "patch_size": 16},
+    {"output_hw": 32, "num_timesteps": 6, "patch_size": 16},
+    {"output_hw": 32, "num_timesteps": 3, "patch_size": 16},
+    {"output_hw": 1, "num_timesteps": 12, "patch_size": 1},
+    {"output_hw": 8, "num_timesteps": 12, "patch_size": 8},
+]
+
+DATA_ABLATIONS = [
+    ["S1"],
+    ["S2_RGB", "S2_Red_Edge", "S2_NIR_10m", "S2_NIR_20m", "S2_SWIR", "NDVI"],
+    ["ERA5"],
+    ["TC"],
+    ["SRTM"],
+    ["location"],
+]
+
+POLL_INTERVAL_SECONDS = 120
+SIGTERM_EXIT_CODE = 128 + signal.SIGTERM
+
+
+def build_experiment_configs() -> list[dict]:
+    experiments: list[dict] = []
+
+    for split_type in SplitType:
+        for load_weights in [True, False]:
+            experiments.append(
+                {
+                    "split_type": split_type,
+                    "load_weights": load_weights,
+                    "output_hw": 32,
+                    "num_timesteps": 12,
+                    "patch_size": 16,
+                    "excluded_bands": frozenset(),
+                }
+            )
+
+        for excluded in DATA_ABLATIONS:
+            for load_weights in [True, False]:
+                experiments.append(
+                    {
+                        "split_type": split_type,
+                        "load_weights": load_weights,
+                        "output_hw": 32,
+                        "num_timesteps": 12,
+                        "patch_size": 16,
+                        "excluded_bands": frozenset(excluded),
+                    }
+                )
+
+        for shape in SHAPE_ABLATIONS:
+            experiments.append(
+                {
+                    "split_type": split_type,
+                    "load_weights": True,
+                    "excluded_bands": frozenset(),
+                    **shape,
+                }
+            )
+
+    return experiments
+
+
+def experiment_label(exp: dict, index: int, total: int) -> str:
+    split = exp["split_type"]
+    weights = "pretrained" if exp["load_weights"] else "random"
+    excluded = ",".join(sorted(exp["excluded_bands"])) or "none"
+    shape = f"{exp['output_hw']}hw_{exp['num_timesteps']}ts_{exp['patch_size']}ps"
+    return f"[{index}/{total}] {split} {weights} {shape} excluded={excluded}"
+
+
+def wait_for_all(experiment_ids: dict[str, str], workspace: str) -> None:
+    """Poll Beaker until all experiments are finalized (succeeded or failed)."""
+    beaker = Beaker.from_env(default_workspace=workspace)
+    pending = dict(experiment_ids)
+
+    print(f"\nWaiting for {len(pending)} experiments to finish...")
+    while pending:
+        time.sleep(POLL_INTERVAL_SECONDS)
+        still_pending = {}
+        for exp_id, label in pending.items():
+            exp = beaker.experiment.get(exp_id)
+            jobs = exp.jobs
+            if not jobs:
+                still_pending[exp_id] = label
+                continue
+            latest_job = jobs[-1]
+            status = latest_job.status
+            if status.finalized is None:
+                still_pending[exp_id] = label
+            elif status.exit_code == SIGTERM_EXIT_CODE:
+                print(f"  Preempted: {label} -- waiting for auto-resume...")
+                still_pending[exp_id] = label
+            else:
+                result = "succeeded" if status.exit_code == 0 else f"failed (exit_code={status.exit_code})"
+                print(f"  Finished: {label} -- {result}")
+        pending = still_pending
+        if pending:
+            print(f"  {len(pending)} experiments still running...")
+
+    print("\nAll experiments finished.")
+
+
+def launch_all(
+    beaker_args: BeakerArgs,
+    model_name: str,
+    data_folder: Path,
+    h5py_folder: Path,
+    h5pys_only: bool,
+    dry_run: bool = False,
+    wait: bool = False,
+) -> None:
+    experiments = build_experiment_configs()
+    print(f"Total experiments: {len(experiments)}")
+
+    launched: dict[str, str] = {}
+    for i, exp in enumerate(experiments, 1):
+        label = experiment_label(exp, i, len(experiments))
+
+        if dry_run:
+            print(f"  DRY RUN: {label}")
+            continue
+
+        print(f"  Launching: {label}")
+        exp_id = launch_experiment(
+            beaker_args=beaker_args,
+            model_name=model_name,
+            data_folder=data_folder,
+            h5py_folder=h5py_folder,
+            h5pys_only=h5pys_only,
+            output_hw=exp["output_hw"],
+            num_timesteps=exp["num_timesteps"],
+            patch_size=exp["patch_size"],
+            load_weights=exp["load_weights"],
+            split_type=exp["split_type"],
+            validation_state_regions=None,
+            test_state_regions=None,
+            excluded_bands=exp["excluded_bands"],
+        )
+        launched[exp_id] = label
+
+    if wait and launched:
+        wait_for_all(launched, beaker_args.workspace)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Launch all paper experiments on Beaker")
+    add_common_beaker_args(parser)
+    parser.add_argument("--model-name", choices={"base", "nano", "tiny"}, required=True)
+    parser.add_argument("--data-folder", type=Path, required=True)
+    parser.add_argument("--h5py-folder", type=Path, required=True)
+    parser.add_argument("--h5pys-only", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--dry-run", action="store_true", help="Print experiments without launching")
+    args = parser.parse_args()
+    beaker_args = get_beaker_args(args)
+    wait = beaker_args.wait
+    beaker_args.wait = False
+
+    launch_all(
+        beaker_args=beaker_args,
+        model_name=args.model_name,
+        data_folder=args.data_folder,
+        h5py_folder=args.h5py_folder,
+        h5pys_only=args.h5pys_only,
+        dry_run=args.dry_run,
+        wait=wait,
+    )

--- a/experiment/beaker_finetune.py
+++ b/experiment/beaker_finetune.py
@@ -12,6 +12,8 @@ from beaker import (
 )
 from beaker.services.experiment import ExperimentClient
 
+from lfmc.core.splits import SplitType
+
 from .beaker_args import BeakerArgs, add_common_beaker_args, get_beaker_args
 
 
@@ -25,10 +27,11 @@ def launch_experiment(
     num_timesteps: int,
     patch_size: int,
     load_weights: bool,
+    split_type: SplitType,
     validation_state_regions: frozenset[str] | None,
     test_state_regions: frozenset[str] | None,
     excluded_bands: frozenset[str],
-) -> None:
+) -> str:
     """Launch experiment for LFMC model finetuning on Beaker.
 
     Args:
@@ -41,14 +44,18 @@ def launch_experiment(
         num_timesteps: The number of timesteps
         patch_size: The patch size
         load_weights: Whether to load the weights
+        split_type: The split strategy (random or spatial)
         validation_state_regions: The state regions to use for validation
         test_state_regions: The state regions to use for testing
         excluded_bands: The bands to exclude
+
+    Returns:
+        The Beaker experiment ID
     """
     beaker = Beaker.from_env(default_workspace=beaker_args.workspace)
     weka_path = PurePath("/weka")
 
-    task_name = f"lfmc_finetune_{model_name}_{output_hw}hw_{num_timesteps}ts_{patch_size}ps"
+    task_name = f"lfmc_finetune_{model_name}_{output_hw}hw_{num_timesteps}ts_{patch_size}ps_{split_type}"
     if not load_weights:
         task_name += "_no_weights"
     with beaker.session():
@@ -63,6 +70,7 @@ def launch_experiment(
             f"--output-timesteps={num_timesteps}",
             f"--patch-size={patch_size}",
             "--load-weights" if load_weights else "--no-load-weights",
+            f"--split-type={split_type}",
         ]
         if validation_state_regions:
             arguments.append(f"--validation-state-regions={','.join(validation_state_regions)}")
@@ -106,6 +114,7 @@ def launch_experiment(
             result_dataset = experiment_client.results(experiment.id)
             if result_dataset is not None:
                 print(f"Result dataset: {result_dataset.id}")
+        return experiment.id
 
 
 if __name__ == "__main__":
@@ -160,6 +169,12 @@ if __name__ == "__main__":
         help="Whether to load the weights",
     )
     parser.add_argument(
+        "--split-type",
+        choices=[s.value for s in SplitType],
+        default=SplitType.RANDOM.value,
+        help="Split strategy: 'random' splits by sorting_id, 'spatial' splits by site_name",
+    )
+    parser.add_argument(
         "--validation-state-regions",
         nargs="*",
         help="The state regions to use for validation",
@@ -187,6 +202,7 @@ if __name__ == "__main__":
         num_timesteps=args.num_timesteps,
         patch_size=args.patch_size,
         load_weights=args.load_weights,
+        split_type=SplitType(args.split_type),
         validation_state_regions=frozenset(args.validation_state_regions) if args.validation_state_regions else None,
         test_state_regions=frozenset(args.test_state_regions) if args.test_state_regions else None,
         excluded_bands=frozenset(args.excluded_bands) if args.excluded_bands else frozenset(),

--- a/experiment/fetch_results.sh
+++ b/experiment/fetch_results.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="${1:-results/raw}"
+WORKSPACE="${BEAKER_WORKSPACE:?Set BEAKER_WORKSPACE environment variable}"
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "Listing lfmc_finetune experiments in $WORKSPACE..."
+EXP_IDS=$(beaker workspace experiments "$WORKSPACE" --text lfmc_finetune --format json | \
+  python3 -c "import json,sys; [print(e['id']) for e in json.load(sys.stdin)]")
+
+TOTAL=$(echo "$EXP_IDS" | wc -l | tr -d ' ')
+echo "Found $TOTAL experiments. Downloading results.json and experiment_config.json..."
+
+COUNT=0
+for exp_id in $EXP_IDS; do
+  COUNT=$((COUNT + 1))
+  echo "[$COUNT/$TOTAL] Fetching $exp_id..."
+  beaker experiment results "$exp_id" --output "$OUTPUT_DIR/$exp_id" --prefix results.json 2>/dev/null || true
+  beaker experiment results "$exp_id" --output "$OUTPUT_DIR/$exp_id" --prefix experiment_config.json 2>/dev/null || true
+
+  # Inject completed_at from Beaker job metadata into each experiment_config.json
+  FINALIZED=$(beaker experiment get "$exp_id" --format json 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)[0]
+jobs = data.get('jobs', [])
+if jobs:
+    print(jobs[-1].get('status', {}).get('finalized', ''))
+" 2>/dev/null || true)
+
+  if [ -n "$FINALIZED" ]; then
+    find "$OUTPUT_DIR/$exp_id" -name experiment_config.json -exec python3 -c "
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    config = json.load(f)
+config['completed_at'] = sys.argv[2]
+with open(path, 'w') as f:
+    json.dump(config, f)
+" {} "$FINALIZED" \;
+  fi
+done
+
+echo "Done. Results saved to $OUTPUT_DIR/"
+echo "Run: PYENV_VERSION=lfmc collect-results --results-dir $OUTPUT_DIR"

--- a/lfmc/core/dataset.py
+++ b/lfmc/core/dataset.py
@@ -24,7 +24,14 @@ from lfmc.core.filter import Filter, apply_filter
 from lfmc.core.labels import read_labels
 from lfmc.core.mode import Mode
 from lfmc.core.padding import pad_dates
-from lfmc.core.splits import assign_random_folds, assign_splits_from_folds, assign_splits_from_values, num_folds
+from lfmc.core.splits import (
+    SPLIT_TYPE_COLUMN,
+    SplitType,
+    assign_random_folds,
+    assign_splits_from_folds,
+    assign_splits_from_values,
+    num_folds,
+)
 
 
 @dataclass(frozen=True)
@@ -51,6 +58,7 @@ class LFMCDataset(Dataset):
         time_bands: FrozenList[str] = FrozenList(TIME_BANDS),
         static_bands: FrozenList[str] = FrozenList(STATIC_BANDS),
         mode: Mode | None = None,
+        split_type: SplitType = SplitType.RANDOM,
         validation_folds: frozenset[int] | None = None,
         test_folds: frozenset[int] | None = None,
         validation_state_regions: frozenset[str] | None = None,
@@ -75,6 +83,7 @@ class LFMCDataset(Dataset):
             f"time_bands: {time_bands}\n"
             f"static_bands: {static_bands}\n"
             f"mode: {mode}\n"
+            f"split_type: {split_type}\n"
             f"validation_folds: {validation_folds}\n"
             f"test_folds: {test_folds}\n"
             f"validation_state_regions: {validation_state_regions}\n"
@@ -107,7 +116,7 @@ class LFMCDataset(Dataset):
                     raise ValueError("validation_folds must be provided")
                 if test_folds is None:
                     raise ValueError("test_folds must be provided")
-                data = assign_random_folds(data, Column.SORTING_ID, num_folds=num_folds())
+                data = assign_random_folds(data, SPLIT_TYPE_COLUMN[split_type], num_folds=num_folds())
                 data = assign_splits_from_folds(data, validation_folds, test_folds)
             else:
                 data = assign_splits_from_values(

--- a/lfmc/core/eval.py
+++ b/lfmc/core/eval.py
@@ -23,6 +23,7 @@ from lfmc.core.filter import Filter
 from lfmc.core.finetuning import DEFAULT_FINETUNING_CONFIG, FinetuningConfig, FineTuningModel
 from lfmc.core.hyperparameters import DEFAULT_HYPERPARAMETERS, HyperParameters
 from lfmc.core.mode import Mode
+from lfmc.core.splits import SplitType
 
 logger = getLogger(__name__)
 
@@ -47,6 +48,7 @@ class LFMCEval:
         output_hw: int = 32,
         output_timesteps: int = 12,
         patch_size: int = 16,
+        split_type: SplitType = SplitType.RANDOM,
         validation_folds: frozenset[int] | None = None,
         test_folds: frozenset[int] | None = None,
         validation_state_regions: frozenset[str] | None = None,
@@ -68,6 +70,7 @@ class LFMCEval:
         self.output_hw = output_hw
         self.output_timesteps = output_timesteps
         self.patch_size = patch_size
+        self.split_type = split_type
         self.validation_folds = validation_folds
         self.test_folds = test_folds
         self.validation_state_regions = validation_state_regions
@@ -100,7 +103,9 @@ class LFMCEval:
             "best_loss": state.best_loss,
             "epochs_since_improvement": state.epochs_since_improvement,
         }
-        torch.save(checkpoint_dict, checkpoint_folder / "checkpoint.pth")
+        tmp_path = checkpoint_folder / "checkpoint.pth.tmp"
+        torch.save(checkpoint_dict, tmp_path)
+        tmp_path.replace(checkpoint_folder / "checkpoint.pth")
 
     def _load_checkpoint(
         self,
@@ -135,6 +140,7 @@ class LFMCEval:
             output_hw=self.output_hw,
             output_timesteps=self.output_timesteps,
             mode=mode,
+            split_type=self.split_type,
             validation_folds=self.validation_folds,
             test_folds=self.test_folds,
             validation_state_regions=self.validation_state_regions,
@@ -193,7 +199,7 @@ class LFMCEval:
         # Load checkpoint if it exists
         finetuning_model, optimizer, state = self._load_checkpoint(output_folder, finetuning_model, optimizer, state)
 
-        for epoch in (pbar := tqdm(range(finetuning_config.max_epochs), desc="Finetuning")):
+        for epoch in (pbar := tqdm(range(state.epoch, finetuning_config.max_epochs), desc="Finetuning")):
             finetuning_model.train()
             epoch_train_loss = 0.0
 
@@ -249,11 +255,13 @@ class LFMCEval:
                 state.epochs_since_improvement = 0
             else:
                 state.epochs_since_improvement += 1
-                if state.epochs_since_improvement >= finetuning_config.patience:
-                    logger.info(f"Early stopping at epoch {epoch} with validation loss {validation_loss:.4f}")
-                    break
 
+            state.epoch = epoch
             self._save_checkpoint(output_folder, finetuning_model, optimizer, state)
+
+            if state.epochs_since_improvement >= finetuning_config.patience:
+                logger.info(f"Early stopping at epoch {epoch} with validation loss {validation_loss:.4f}")
+                break
 
         if state.best_model_dict is None:
             raise ValueError("No best model found")
@@ -356,6 +364,7 @@ def finetune_and_evaluate(
     patch_size: int = 16,
     hyperparams: HyperParameters = DEFAULT_HYPERPARAMETERS,
     finetuning_config: FinetuningConfig = DEFAULT_FINETUNING_CONFIG,
+    split_type: SplitType = SplitType.RANDOM,
     validation_folds: frozenset[int] | None = None,
     test_folds: frozenset[int] | None = None,
     validation_state_regions: frozenset[str] | None = None,
@@ -371,6 +380,7 @@ def finetune_and_evaluate(
     logger.info("Patch size: %s", patch_size)
     logger.info("Hyperparams: %s", hyperparams)
     logger.info("Finetuning config: %s", finetuning_config)
+    logger.info("Split type: %s", split_type)
     logger.info("Validation folds: %s", validation_folds)
     logger.info("Test folds: %s", test_folds)
     logger.info("Validation state regions: %s", validation_state_regions)
@@ -410,6 +420,7 @@ def finetune_and_evaluate(
         output_hw=output_hw,
         output_timesteps=output_timesteps,
         patch_size=patch_size,
+        split_type=split_type,
         validation_folds=validation_folds,
         test_folds=test_folds,
         validation_state_regions=validation_state_regions,

--- a/lfmc/core/splits.py
+++ b/lfmc/core/splits.py
@@ -1,10 +1,26 @@
 import hashlib
 import os
 import random
+from enum import StrEnum
 
 import pandas as pd
+from frozendict import frozendict
 
+from lfmc.core.const import Column
 from lfmc.core.mode import Mode
+
+
+class SplitType(StrEnum):
+    RANDOM = "random"
+    SPATIAL = "spatial"
+
+
+SPLIT_TYPE_COLUMN: frozendict[SplitType, Column] = frozendict(
+    {
+        SplitType.RANDOM: Column.SORTING_ID,
+        SplitType.SPATIAL: Column.SITE_NAME,
+    }
+)
 
 DEFAULT_NUM_FOLDS = 100
 

--- a/lfmc/main/add_splits_to_csv.py
+++ b/lfmc/main/add_splits_to_csv.py
@@ -4,10 +4,12 @@ from pathlib import Path
 
 import pandas as pd
 
-from lfmc.core.const import LABELS_PATH, Column
+from lfmc.core.const import LABELS_PATH
 from lfmc.core.splits import (
     DEFAULT_TEST_FOLDS,
     DEFAULT_VALIDATION_FOLDS,
+    SPLIT_TYPE_COLUMN,
+    SplitType,
     assign_random_folds,
     assign_splits_from_folds,
     num_folds,
@@ -25,51 +27,41 @@ def add_splits_to_csv(input_csv_path: Path, output_csv_path: Path) -> None:
     df = pd.read_csv(input_csv_path)
 
     # Drop existing split columns if they exist
-    columns_to_drop = ["random_split", "spatial_split"]
+    columns_to_drop = [f"{split_type}_split" for split_type in SplitType]
     existing_columns_to_drop = [col for col in columns_to_drop if col in df.columns]
     if existing_columns_to_drop:
         logging.info("Dropping existing split columns: %s", existing_columns_to_drop)
         df = df.drop(columns=existing_columns_to_drop)
 
     # Validate required columns exist
-    required_columns = [Column.SORTING_ID, Column.SITE_NAME]
+    required_columns = list({SPLIT_TYPE_COLUMN[st] for st in SplitType})
     missing_columns = [col for col in required_columns if col not in df.columns]
     if missing_columns:
         raise ValueError(f"Missing required columns: {missing_columns}")
 
-    # Compute random_split
-    logging.info("Applying deterministic fold assignment for random splits")
-    df = assign_random_folds(df, Column.SORTING_ID, num_folds=num_folds())
-    logging.info("Assigning random splits from folds")
-    df = assign_splits_from_folds(df, DEFAULT_VALIDATION_FOLDS, DEFAULT_TEST_FOLDS)
-    df = df.rename(columns={"mode": "random_split"})
-    df = df.drop(columns=["fold"])
+    for split_type in SplitType:
+        column_name = f"{split_type}_split"
+        id_column = SPLIT_TYPE_COLUMN[split_type]
+        logging.info("Applying deterministic fold assignment for %s splits (column: %s)", split_type, id_column)
+        df = assign_random_folds(df, id_column, num_folds=num_folds())
+        logging.info("Assigning %s splits from folds", split_type)
+        df = assign_splits_from_folds(df, DEFAULT_VALIDATION_FOLDS, DEFAULT_TEST_FOLDS)
+        df = df.rename(columns={"mode": column_name})
+        df = df.drop(columns=["fold"])
 
-    # Compute spatial_split
-    logging.info("Applying deterministic fold assignment for spatial splits")
-    df = assign_random_folds(df, Column.SITE_NAME, num_folds=num_folds())
-    logging.info("Assigning spatial splits from folds")
-    df = assign_splits_from_folds(df, DEFAULT_VALIDATION_FOLDS, DEFAULT_TEST_FOLDS)
-    df = df.rename(columns={"mode": "spatial_split"})
-    df = df.drop(columns=["fold"])
-
-    # Reorder columns to put random_split and spatial_split at the end
-    original_columns = [col for col in df.columns if col not in ["random_split", "spatial_split"]]
-    df = df[original_columns + ["random_split", "spatial_split"]]
+    split_columns = [f"{split_type}_split" for split_type in SplitType]
+    original_columns = [col for col in df.columns if col not in split_columns]
+    df = df[original_columns + split_columns]
 
     logging.info("Writing CSV file with splits: %s", output_csv_path)
     df.to_csv(output_csv_path, index=False)
 
-    # Log split distribution
-    logging.info("Random split distribution:")
-    random_split_counts = df["random_split"].value_counts()
-    for split, count in random_split_counts.items():
-        logging.info("  %s: %d rows (%.2f%%)", split, count, 100 * count / len(df))
-
-    logging.info("Spatial split distribution:")
-    spatial_split_counts = df["spatial_split"].value_counts()
-    for split, count in spatial_split_counts.items():
-        logging.info("  %s: %d rows (%.2f%%)", split, count, 100 * count / len(df))
+    for split_type in SplitType:
+        column_name = f"{split_type}_split"
+        logging.info("%s split distribution:", split_type.value.capitalize())
+        split_counts = df[column_name].value_counts()
+        for split, count in split_counts.items():
+            logging.info("  %s: %d rows (%.2f%%)", split, count, 100 * count / len(df))
 
 
 def main():

--- a/lfmc/main/collect_results.py
+++ b/lfmc/main/collect_results.py
@@ -1,0 +1,523 @@
+import argparse
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_excluded_bands(bands: str) -> str:
+    if not bands:
+        return ""
+    normalized = {band.strip() for band in bands.split(",") if band.strip()}
+    return ",".join(sorted(normalized))
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    split_type: str
+    load_weights: bool
+    excluded_bands: str
+    output_hw: int
+    output_timesteps: int
+    patch_size: int
+
+    @property
+    def is_default_shape(self) -> bool:
+        return self.output_hw == 32 and self.output_timesteps == 12 and self.patch_size == 16
+
+    @property
+    def has_excluded_bands(self) -> bool:
+        return self.excluded_bands != ""
+
+
+ResultsDict = dict[str, dict[str, float]]
+
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    results: ResultsDict
+    path: Path
+    completed_at: str
+
+
+EXCLUDED_BANDS_DISPLAY: dict[str, str] = {
+    _normalize_excluded_bands(""): "None",
+    _normalize_excluded_bands("S1"): "S1",
+    _normalize_excluded_bands("S2_RGB,S2_Red_Edge,S2_NIR_10m,S2_NIR_20m,S2_SWIR,NDVI"): "S2",
+    _normalize_excluded_bands("ERA5"): "ERA5",
+    _normalize_excluded_bands("TC"): "TC",
+    _normalize_excluded_bands("SRTM"): "SRTM",
+    _normalize_excluded_bands("location"): "loc.",
+}
+
+
+def _metrics_row(results: ResultsDict, key: str) -> str:
+    if key not in results:
+        return "- | - | -"
+    m = results[key]
+    return f"{m['rmse']:.2f} | {m['mae']:.2f} | {m['r2_score']:.2f}"
+
+
+def _find_experiment(
+    experiments: list[Experiment],
+    split_type: str,
+    load_weights: bool,
+    excluded_bands: str = "",
+    output_hw: int = 32,
+    output_timesteps: int = 12,
+    patch_size: int = 16,
+) -> Experiment | None:
+    for exp in experiments:
+        if (
+            exp.config.split_type == split_type
+            and exp.config.load_weights == load_weights
+            and exp.config.excluded_bands == excluded_bands
+            and exp.config.output_hw == output_hw
+            and exp.config.output_timesteps == output_timesteps
+            and exp.config.patch_size == patch_size
+        ):
+            return exp
+    return None
+
+
+def load_experiments(results_dir: Path) -> list[Experiment]:
+    by_config: dict[ExperimentConfig, Experiment] = {}
+    for config_path in sorted(results_dir.rglob("experiment_config.json")):
+        folder = config_path.parent
+        results_path = folder / "results.json"
+        if not results_path.exists():
+            logger.warning("Skipping %s: no results.json found", folder)
+            continue
+        with open(config_path) as f:
+            config_data = json.load(f)
+        with open(results_path) as f:
+            results_data = json.load(f)
+        config = ExperimentConfig(
+            split_type=config_data["split_type"],
+            load_weights=config_data["load_weights"],
+            excluded_bands=_normalize_excluded_bands(config_data.get("excluded_bands", "")),
+            output_hw=config_data["output_hw"],
+            output_timesteps=config_data["output_timesteps"],
+            patch_size=config_data["patch_size"],
+        )
+        completed_at = config_data.get("completed_at", "")
+        experiment = Experiment(config=config, results=results_data, path=folder, completed_at=completed_at)
+        if config in by_config:
+            existing = by_config[config]
+            if experiment.completed_at > existing.completed_at:
+                logger.info("Duplicate config, keeping newer: %s over %s", folder, existing.path)
+                by_config[config] = experiment
+            else:
+                logger.info("Duplicate config, keeping newer: %s over %s", existing.path, folder)
+        else:
+            by_config[config] = experiment
+    experiments = list(by_config.values())
+    logger.info("Loaded %d experiments from %s", len(experiments), results_dir)
+    return experiments
+
+
+def generate_table_1(experiments: list[Experiment], split_type: str) -> str:
+    """Pretrained vs Random initialized vs Monthly predictions baseline."""
+    pretrained = _find_experiment(experiments, split_type, load_weights=True)
+    random_init = _find_experiment(experiments, split_type, load_weights=False)
+
+    lines = [
+        "| Category | RMSE | MAE | R2 |",
+        "| --- | --- | --- | --- |",
+    ]
+    if pretrained:
+        lines.append(f"| Pretrained | {_metrics_row(pretrained.results, 'all')} |")
+    if random_init:
+        lines.append(f"| Random initialized | {_metrics_row(random_init.results, 'all')} |")
+    baseline_exp = pretrained or random_init
+    if baseline_exp:
+        lines.append(f"| Monthly predictions | {_metrics_row(baseline_exp.results, 'baseline')} |")
+
+    return "\n".join(lines)
+
+
+def generate_table_2(experiments: list[Experiment], split_type: str) -> str:
+    """Season breakdown from the default pretrained experiment."""
+    pretrained = _find_experiment(experiments, split_type, load_weights=True)
+    if not pretrained:
+        return "*No default pretrained experiment found.*"
+
+    keys_display = [
+        ("all", "Overall"),
+        ("Winter", "Winter season"),
+        ("Spring", "Spring season"),
+        ("Summer", "Summer season"),
+        ("Autumn", "Autumn season"),
+    ]
+    lines = [
+        "| Season | RMSE | MAE | R2 |",
+        "| --- | --- | --- | --- |",
+    ]
+    for key, display in keys_display:
+        lines.append(f"| {display} | {_metrics_row(pretrained.results, key)} |")
+    return "\n".join(lines)
+
+
+def generate_table_3(experiments: list[Experiment], split_type: str) -> str:
+    """Land cover breakdown from the default pretrained experiment."""
+    pretrained = _find_experiment(experiments, split_type, load_weights=True)
+    if not pretrained:
+        return "*No default pretrained experiment found.*"
+
+    keys_display = [
+        ("all", "Overall"),
+        ("Tree cover", "Trees"),
+        ("Grassland", "Grass"),
+        ("Shrubland", "Shrub"),
+        ("Built-up", "Built-up"),
+        ("Bare / sparse vegetation", "Bare / Sparse"),
+    ]
+    lines = [
+        "| Land Cover Class | RMSE | MAE | R2 |",
+        "| --- | --- | --- | --- |",
+    ]
+    for key, display in keys_display:
+        lines.append(f"| {display} | {_metrics_row(pretrained.results, key)} |")
+    return "\n".join(lines)
+
+
+def generate_table_4(experiments: list[Experiment], split_type: str) -> str:
+    """Elevation breakdown from the default pretrained experiment."""
+    pretrained = _find_experiment(experiments, split_type, load_weights=True)
+    if not pretrained:
+        return "*No default pretrained experiment found.*"
+
+    keys_display = [
+        ("all", "Overall"),
+        ("elevation_0_500", "Elevation: 0-500m"),
+        ("elevation_500_1000", "Elevation: 500-1000m"),
+        ("elevation_1000_1500", "Elevation: 1000-1500m"),
+        ("elevation_1500_2000", "Elevation: 1500-2000m"),
+        ("elevation_2000_2500", "Elevation: 2000-2500m"),
+        ("elevation_2500_3000", "Elevation: 2500-3000m"),
+        ("elevation_3000_3500", "Elevation: 3000-3500m"),
+    ]
+    lines = [
+        "| Category | RMSE | MAE | R2 |",
+        "| --- | --- | --- | --- |",
+    ]
+    for key, display in keys_display:
+        lines.append(f"| {display} | {_metrics_row(pretrained.results, key)} |")
+    return "\n".join(lines)
+
+
+def generate_table_5(experiments: list[Experiment], split_type: str) -> str:
+    """Shape ablations -- pretrained only, varying output_hw/output_timesteps/patch_size."""
+    shape_experiments = [
+        exp
+        for exp in experiments
+        if exp.config.split_type == split_type and exp.config.load_weights and not exp.config.has_excluded_bands
+    ]
+
+    def sort_key(exp: Experiment) -> tuple[int, int, int, int]:
+        c = exp.config
+        is_default = int(not c.is_default_shape)
+        return (is_default, -c.output_hw, -c.output_timesteps, -c.patch_size)
+
+    shape_experiments.sort(key=sort_key)
+
+    if not shape_experiments:
+        return "*No shape experiments found.*"
+
+    lines = [
+        "| H, W | T | P | RMSE | MAE | R2 |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for exp in shape_experiments:
+        c = exp.config
+        lines.append(f"| {c.output_hw} | {c.output_timesteps} | {c.patch_size} | {_metrics_row(exp.results, 'all')} |")
+    return "\n".join(lines)
+
+
+def generate_table_6(experiments: list[Experiment], split_type: str) -> str:
+    """Data ablations -- pretrained and random, each with one input removed."""
+    data_experiments: dict[str, dict[bool, Experiment]] = {}
+    for exp in experiments:
+        if exp.config.split_type == split_type and exp.config.is_default_shape:
+            excluded = exp.config.excluded_bands
+            if excluded not in data_experiments:
+                data_experiments[excluded] = {}
+            data_experiments[excluded][exp.config.load_weights] = exp
+
+    ordered_keys = [""]
+    for key in sorted(data_experiments.keys()):
+        if key != "":
+            ordered_keys.append(key)
+
+    lines = [
+        "| Excluded | PT RMSE | PT MAE | PT R2 | RI RMSE | RI MAE | RI R2 |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for excluded_key in ordered_keys:
+        if excluded_key not in data_experiments:
+            continue
+        display_name = EXCLUDED_BANDS_DISPLAY.get(excluded_key, excluded_key)
+        exps = data_experiments[excluded_key]
+        pretrained = exps.get(True)
+        random_init = exps.get(False)
+        pretrained_metrics = _metrics_row(pretrained.results, "all") if pretrained else "- | - | -"
+        random_metrics = _metrics_row(random_init.results, "all") if random_init else "- | - | -"
+        lines.append(f"| {display_name} | {pretrained_metrics} | {random_metrics} |")
+
+    return "\n".join(lines)
+
+
+TABLE_GENERATORS: list[tuple[str, Callable[[list[Experiment], str], str]]] = [
+    ("Table 1: Overall Results", generate_table_1),
+    ("Table 2: Season Breakdown", generate_table_2),
+    ("Table 3: Land Cover Breakdown", generate_table_3),
+    ("Table 4: Elevation Breakdown", generate_table_4),
+    ("Table 5: Shape Ablations", generate_table_5),
+    ("Table 6: Data Ablations", generate_table_6),
+]
+
+
+def _combined_breakdown(
+    experiments: list[Experiment],
+    keys_display: list[tuple[str, str]],
+    header_label: str,
+) -> str:
+    """Side-by-side random vs spatial for a single pretrained breakdown."""
+    random_exp = _find_experiment(experiments, "random", load_weights=True)
+    spatial_exp = _find_experiment(experiments, "spatial", load_weights=True)
+    if not random_exp and not spatial_exp:
+        return "*No experiments found.*"
+
+    lines = [
+        f"| {header_label} | Random RMSE | Random MAE | Random R2 | Spatial RMSE | Spatial MAE | Spatial R2 |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for key, display in keys_display:
+        rand = _metrics_row(random_exp.results, key) if random_exp else "- | - | -"
+        spat = _metrics_row(spatial_exp.results, key) if spatial_exp else "- | - | -"
+        lines.append(f"| {display} | {rand} | {spat} |")
+    return "\n".join(lines)
+
+
+def generate_combined_table_1(experiments: list[Experiment]) -> str:
+    random_pt = _find_experiment(experiments, "random", load_weights=True)
+    random_ri = _find_experiment(experiments, "random", load_weights=False)
+    spatial_pt = _find_experiment(experiments, "spatial", load_weights=True)
+    spatial_ri = _find_experiment(experiments, "spatial", load_weights=False)
+
+    lines = [
+        "| Category | Random RMSE | Random MAE | Random R2 | Spatial RMSE | Spatial MAE | Spatial R2 |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    rand_pt = _metrics_row(random_pt.results, "all") if random_pt else "- | - | -"
+    spat_pt = _metrics_row(spatial_pt.results, "all") if spatial_pt else "- | - | -"
+    lines.append(f"| Pretrained | {rand_pt} | {spat_pt} |")
+
+    rand_ri = _metrics_row(random_ri.results, "all") if random_ri else "- | - | -"
+    spat_ri = _metrics_row(spatial_ri.results, "all") if spatial_ri else "- | - | -"
+    lines.append(f"| Random init | {rand_ri} | {spat_ri} |")
+
+    baseline_exp_r = random_pt or random_ri
+    baseline_exp_s = spatial_pt or spatial_ri
+    rand_bl = _metrics_row(baseline_exp_r.results, "baseline") if baseline_exp_r else "- | - | -"
+    spat_bl = _metrics_row(baseline_exp_s.results, "baseline") if baseline_exp_s else "- | - | -"
+    lines.append(f"| Monthly pred | {rand_bl} | {spat_bl} |")
+
+    return "\n".join(lines)
+
+
+def generate_combined_table_2(experiments: list[Experiment]) -> str:
+    return _combined_breakdown(
+        experiments,
+        [
+            ("all", "Overall"),
+            ("Winter", "Winter"),
+            ("Spring", "Spring"),
+            ("Summer", "Summer"),
+            ("Autumn", "Autumn"),
+        ],
+        "Season",
+    )
+
+
+def generate_combined_table_3(experiments: list[Experiment]) -> str:
+    table = _combined_breakdown(
+        experiments,
+        [
+            ("all", "Overall"),
+            ("Tree cover", "Trees"),
+            ("Grassland", "Grass"),
+            ("Shrubland", "Shrub"),
+            ("Built-up", "Built-up"),
+            ("Bare / sparse vegetation", "Bare / Sparse"),
+        ],
+        "Land Cover",
+    )
+    table += (
+        "\n\nBuilt-up and Bare/Sparse have limited site diversity"
+        " (21 and 15 sites respectively), which may reduce the"
+        " reliability of spatial split metrics for these classes."
+    )
+    return table
+
+
+def generate_combined_table_4(experiments: list[Experiment]) -> str:
+    return _combined_breakdown(
+        experiments,
+        [
+            ("all", "Overall"),
+            ("elevation_0_500", "0-500m"),
+            ("elevation_500_1000", "500-1000m"),
+            ("elevation_1000_1500", "1000-1500m"),
+            ("elevation_1500_2000", "1500-2000m"),
+            ("elevation_2000_2500", "2000-2500m"),
+            ("elevation_2500_3000", "2500-3000m"),
+            ("elevation_3000_3500", "3000-3500m"),
+        ],
+        "Elevation",
+    )
+
+
+def generate_combined_table_5(experiments: list[Experiment]) -> str:
+    shape_configs: list[tuple[int, int, int]] = []
+    for exp in experiments:
+        c = exp.config
+        if c.load_weights and not c.has_excluded_bands:
+            key = (c.output_hw, c.output_timesteps, c.patch_size)
+            if key not in shape_configs:
+                shape_configs.append(key)
+
+    def sort_key(k: tuple[int, int, int]) -> tuple[int, int, int, int]:
+        is_default = int(not (k[0] == 32 and k[1] == 12 and k[2] == 16))
+        return (is_default, -k[0], -k[1], -k[2])
+
+    shape_configs.sort(key=sort_key)
+
+    if not shape_configs:
+        return "*No shape experiments found.*"
+
+    lines = [
+        "| H, W | T | P | Random RMSE | Random MAE | Random R2 | Spatial RMSE | Spatial MAE | Spatial R2 |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for hw, ts, ps in shape_configs:
+        rand = _find_experiment(
+            experiments, "random", load_weights=True, output_hw=hw, output_timesteps=ts, patch_size=ps
+        )
+        spat = _find_experiment(
+            experiments, "spatial", load_weights=True, output_hw=hw, output_timesteps=ts, patch_size=ps
+        )
+        r = _metrics_row(rand.results, "all") if rand else "- | - | -"
+        s = _metrics_row(spat.results, "all") if spat else "- | - | -"
+        lines.append(f"| {hw} | {ts} | {ps} | {r} | {s} |")
+    return "\n".join(lines)
+
+
+def generate_combined_table_6(experiments: list[Experiment]) -> str:
+    excluded_keys: list[str] = [""]
+    seen = {""}
+    for exp in experiments:
+        c = exp.config
+        if c.is_default_shape and c.excluded_bands not in seen:
+            seen.add(c.excluded_bands)
+            excluded_keys.append(c.excluded_bands)
+
+    lines = [
+        "| Excluded | Rnd PT RMSE | Rnd PT MAE | Rnd PT R2 | Rnd RI RMSE | Rnd RI MAE | Rnd RI R2 | Spt PT RMSE | Spt PT MAE | Spt PT R2 | Spt RI RMSE | Spt RI MAE | Spt RI R2 |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+
+    for excluded_key in excluded_keys:
+        display = EXCLUDED_BANDS_DISPLAY.get(excluded_key, excluded_key)
+        rpt = _find_experiment(experiments, "random", True, excluded_bands=excluded_key)
+        rri = _find_experiment(experiments, "random", False, excluded_bands=excluded_key)
+        spt = _find_experiment(experiments, "spatial", True, excluded_bands=excluded_key)
+        sri = _find_experiment(experiments, "spatial", False, excluded_bands=excluded_key)
+        lines.append(
+            f"| {display} | {_metrics_row(rpt.results, 'all') if rpt else '- | - | -'}"
+            f" | {_metrics_row(rri.results, 'all') if rri else '- | - | -'}"
+            f" | {_metrics_row(spt.results, 'all') if spt else '- | - | -'}"
+            f" | {_metrics_row(sri.results, 'all') if sri else '- | - | -'} |"
+        )
+    lines.append("")
+    lines.append("Rnd = Random split, Spt = Spatial split, PT = Pretrained, RI = Random Initialized")
+    return "\n".join(lines)
+
+
+COMBINED_TABLE_GENERATORS: list[tuple[str, Callable[[list[Experiment]], str]]] = [
+    ("Table 1: Overall Results", generate_combined_table_1),
+    ("Table 2: Season Breakdown", generate_combined_table_2),
+    ("Table 3: Land Cover Breakdown", generate_combined_table_3),
+    ("Table 4: Elevation Breakdown", generate_combined_table_4),
+    ("Table 5: Shape Ablations", generate_combined_table_5),
+    ("Table 6: Data Ablations", generate_combined_table_6),
+]
+
+
+def collect_results(results_dir: Path) -> str:
+    experiments = load_experiments(results_dir)
+    if not experiments:
+        return "No experiments found."
+
+    split_types = sorted({exp.config.split_type for exp in experiments})
+    timestamps = [exp.completed_at for exp in experiments if exp.completed_at]
+    output_parts: list[str] = []
+
+    if timestamps:
+        earliest = min(timestamps)[:10]
+        latest = max(timestamps)[:10]
+        if earliest == latest:
+            output_parts.append(f"*Experiments completed: {latest}*\n")
+        else:
+            output_parts.append(f"*Experiments completed: {earliest} to {latest}*\n")
+
+    if "random" in split_types:
+        output_parts.append(
+            "**Note:** Random split results differ slightly from the published paper"
+            " ([arXiv:2506.20132](https://arxiv.org/abs/2506.20132))."
+            " In particular, the random initialized baseline improved (RMSE 23.61 to 21.88),"
+            " narrowing the gap with the pretrained model from ~20% to ~12%."
+            " The exact cause is unknown but may include differences in random seeds,"
+            " library versions, or a fix to checkpoint resume logic.\n"
+        )
+
+    if len(split_types) > 1:
+        output_parts.append("# Results (random vs spatial)\n")
+        for title, generator in COMBINED_TABLE_GENERATORS:
+            output_parts.append(f"## {title}\n")
+            output_parts.append(generator(experiments))
+            output_parts.append("")
+    else:
+        for split_type in split_types:
+            output_parts.append(f"# Results: {split_type} split\n")
+            for title, table_gen in TABLE_GENERATORS:
+                output_parts.append(f"## {title}\n")
+                output_parts.append(table_gen(experiments, split_type))
+                output_parts.append("")
+
+    return "\n".join(output_parts)
+
+
+def main():
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        level=logging.INFO,
+    )
+    parser = argparse.ArgumentParser("Collect experiment results and generate paper tables")
+    parser.add_argument(
+        "--results-dir",
+        type=Path,
+        required=True,
+        help="Directory containing experiment result subfolders",
+    )
+    args = parser.parse_args()
+    print(collect_results(args.results_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/lfmc/main/finetune_model.py
+++ b/lfmc/main/finetune_model.py
@@ -10,7 +10,7 @@ from galileo.utils import device
 from lfmc.core.copy import copy_dir
 from lfmc.core.encoder_loader import load_from_folder
 from lfmc.core.eval import finetune_and_evaluate
-from lfmc.core.splits import DEFAULT_TEST_FOLDS, DEFAULT_VALIDATION_FOLDS
+from lfmc.core.splits import DEFAULT_TEST_FOLDS, DEFAULT_VALIDATION_FOLDS, SplitType
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +90,12 @@ def main():
         help="The bands to exclude, separated by commas",
     )
     parser.add_argument(
+        "--split-type",
+        choices=[s.value for s in SplitType],
+        default=SplitType.RANDOM.value,
+        help="Split strategy: 'random' splits by sorting_id, 'spatial' splits by site_name",
+    )
+    parser.add_argument(
         "--validation-state-regions",
         type=str,
         help="The state regions to use for validation, separated by commas",
@@ -138,6 +144,7 @@ def main():
             output_hw=args.output_hw,
             output_timesteps=args.output_timesteps,
             patch_size=args.patch_size,
+            split_type=SplitType(args.split_type),
             validation_folds=DEFAULT_VALIDATION_FOLDS if not args.validation_state_regions else None,
             test_folds=DEFAULT_TEST_FOLDS if not args.test_state_regions else None,
             validation_state_regions=args.validation_state_regions.split(",")
@@ -151,6 +158,17 @@ def main():
         with open(args.output_folder / "results.json", "w") as f:
             json.dump(results, f)
         df.to_csv(args.output_folder / "results.csv", index=False)
+
+        experiment_config = {
+            "split_type": args.split_type,
+            "load_weights": args.load_weights,
+            "excluded_bands": args.excluded_bands or "",
+            "output_hw": args.output_hw,
+            "output_timesteps": args.output_timesteps,
+            "patch_size": args.patch_size,
+        }
+        with open(args.output_folder / "experiment_config.json", "w") as f:
+            json.dump(experiment_config, f)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ analyze-csv = "lfmc.main.analyze_csv:main"
 augment-labels = "lfmc.main.augment_labels:main"
 create-csv = "lfmc.main.create_csv:main"
 create-h5pys = "lfmc.main.create_h5pys:main"
+collect-results = "lfmc.main.collect_results:main"
 evaluate-model = "lfmc.main.evaluate_model:main"
 finetune-model = "lfmc.main.finetune_model:main"
 

--- a/results/tables.md
+++ b/results/tables.md
@@ -1,0 +1,75 @@
+*Experiments completed: 2026-04-07 to 2026-04-11*
+
+**Note:** Random split results differ slightly from the published paper ([arXiv:2506.20132](https://arxiv.org/abs/2506.20132)). In particular, the random initialized baseline improved (RMSE 23.61 to 21.88), narrowing the gap with the pretrained model from ~20% to ~12%. The exact cause is unknown but may include differences in random seeds, library versions, or a fix to checkpoint resume logic.
+
+# Results (random vs spatial)
+
+## Table 1: Overall Results
+
+| Category | Random RMSE | Random MAE | Random R2 | Spatial RMSE | Spatial MAE | Spatial R2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Pretrained | 19.14 | 12.80 | 0.71 | 24.90 | 17.68 | 0.48 |
+| Random init | 21.88 | 15.02 | 0.63 | 26.34 | 18.81 | 0.41 |
+| Monthly pred | 33.66 | 25.38 | 0.12 | 32.33 | 25.06 | 0.12 |
+
+## Table 2: Season Breakdown
+
+| Season | Random RMSE | Random MAE | Random R2 | Spatial RMSE | Spatial MAE | Spatial R2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Overall | 19.14 | 12.80 | 0.71 | 24.90 | 17.68 | 0.48 |
+| Winter | 14.72 | 10.06 | 0.79 | 18.77 | 12.90 | 0.41 |
+| Spring | 23.34 | 15.71 | 0.68 | 31.88 | 22.83 | 0.34 |
+| Summer | 19.87 | 13.50 | 0.66 | 25.76 | 18.79 | 0.42 |
+| Autumn | 13.06 | 9.18 | 0.73 | 15.60 | 12.07 | 0.57 |
+
+## Table 3: Land Cover Breakdown
+
+| Land Cover | Random RMSE | Random MAE | Random R2 | Spatial RMSE | Spatial MAE | Spatial R2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Overall | 19.14 | 12.80 | 0.71 | 24.90 | 17.68 | 0.48 |
+| Trees | 18.07 | 12.24 | 0.68 | 25.49 | 18.13 | 0.39 |
+| Grass | 20.93 | 14.10 | 0.71 | 24.39 | 17.30 | 0.55 |
+| Shrub | 19.10 | 12.13 | 0.75 | 24.76 | 17.24 | 0.49 |
+| Built-up | 17.22 | 11.61 | 0.76 | 20.75 | 15.99 | -0.37 |
+| Bare / Sparse | 19.14 | 13.48 | 0.82 | 25.33 | 19.09 | 0.68 |
+
+Built-up and Bare/Sparse have limited site diversity (21 and 15 sites respectively), which may reduce the reliability of spatial split metrics for these classes.
+
+## Table 4: Elevation Breakdown
+
+| Elevation | Random RMSE | Random MAE | Random R2 | Spatial RMSE | Spatial MAE | Spatial R2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Overall | 19.14 | 12.80 | 0.71 | 24.90 | 17.68 | 0.48 |
+| 0-500m | 18.51 | 11.68 | 0.73 | 19.37 | 14.05 | 0.53 |
+| 500-1000m | 18.22 | 12.30 | 0.76 | 23.95 | 16.70 | 0.56 |
+| 1000-1500m | 21.60 | 14.50 | 0.73 | 30.10 | 20.45 | 0.44 |
+| 1500-2000m | 19.09 | 13.69 | 0.74 | 25.91 | 19.34 | 0.49 |
+| 2000-2500m | 19.57 | 12.82 | 0.60 | 24.67 | 18.40 | 0.36 |
+| 2500-3000m | 16.41 | 10.73 | 0.46 | 21.87 | 16.17 | 0.03 |
+| 3000-3500m | 15.70 | 11.50 | 0.20 | 23.85 | 19.38 | -0.10 |
+
+## Table 5: Shape Ablations
+
+| H, W | T | P | Random RMSE | Random MAE | Random R2 | Spatial RMSE | Spatial MAE | Spatial R2 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 32 | 12 | 16 | 19.14 | 12.80 | 0.71 | 24.90 | 17.68 | 0.48 |
+| 32 | 6 | 16 | 19.13 | 12.75 | 0.72 | 25.58 | 17.66 | 0.45 |
+| 32 | 3 | 16 | 20.10 | 13.79 | 0.69 | 26.27 | 17.82 | 0.42 |
+| 16 | 12 | 16 | 19.99 | 13.75 | 0.69 | 25.72 | 17.72 | 0.44 |
+| 8 | 12 | 8 | 19.76 | 13.42 | 0.70 | 25.27 | 17.85 | 0.46 |
+| 1 | 12 | 1 | 20.72 | 13.95 | 0.67 | 24.66 | 17.04 | 0.49 |
+
+## Table 6: Data Ablations
+
+| Excluded | Rnd PT RMSE | Rnd PT MAE | Rnd PT R2 | Rnd RI RMSE | Rnd RI MAE | Rnd RI R2 | Spt PT RMSE | Spt PT MAE | Spt PT R2 | Spt RI RMSE | Spt RI MAE | Spt RI R2 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| None | 19.14 | 12.80 | 0.71 | 21.88 | 15.02 | 0.63 | 24.90 | 17.68 | 0.48 | 26.34 | 18.81 | 0.41 |
+| ERA5 | 18.98 | 12.64 | 0.72 | 26.43 | 18.77 | 0.46 | 25.53 | 17.79 | 0.45 | 27.13 | 20.25 | 0.38 |
+| loc. | 19.27 | 13.37 | 0.71 | 24.23 | 16.96 | 0.54 | 25.96 | 17.97 | 0.43 | 27.86 | 19.58 | 0.35 |
+| S1 | 19.39 | 13.23 | 0.71 | 24.66 | 17.14 | 0.53 | 25.43 | 18.52 | 0.45 | 27.29 | 20.22 | 0.37 |
+| S2 | 19.33 | 12.78 | 0.71 | 25.17 | 18.31 | 0.51 | 25.87 | 17.73 | 0.44 | 27.49 | 19.35 | 0.36 |
+| TC | 18.90 | 12.33 | 0.72 | 22.32 | 15.34 | 0.61 | 26.91 | 18.74 | 0.39 | 26.68 | 18.81 | 0.40 |
+| SRTM | 19.40 | 13.10 | 0.71 | 25.29 | 17.74 | 0.50 | 25.58 | 17.79 | 0.45 | 26.17 | 18.67 | 0.42 |
+
+Rnd = Random split, Spt = Spatial split, PT = Pretrained, RI = Random Initialized
+

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -17,7 +17,7 @@ from lfmc.core.const import MeteorologicalSeason, WorldCoverClass
 from lfmc.core.dataset import LFMCDataset
 from lfmc.core.filter import Filter
 from lfmc.core.mode import Mode
-from lfmc.core.splits import num_folds
+from lfmc.core.splits import SplitType, num_folds
 
 
 def assert_sets_unique(sets: Sequence[set[Any]]):
@@ -42,6 +42,31 @@ def test_dataset_train_validation_test_splits(data_folder: Path, h5py_folder: Pa
             h5py_folder=h5py_folder,
             h5pys_only=False,
             mode=mode,
+            validation_folds=validation_folds,
+            test_folds=test_folds,
+        )
+
+    validation_folds = frozenset([0])
+    test_folds = frozenset([1])
+    train_dataset = create_dataset(Mode.TRAIN, validation_folds, test_folds)
+    validation_dataset = create_dataset(Mode.VALIDATION, validation_folds, test_folds)
+    test_dataset = create_dataset(Mode.TEST, validation_folds, test_folds)
+
+    training_samples = {train_dataset[i][1] for i in range(len(train_dataset))}
+    validation_samples = {validation_dataset[i][1] for i in range(len(validation_dataset))}
+    test_samples = {test_dataset[i][1] for i in range(len(test_dataset))}
+    assert_sets_unique([training_samples, validation_samples, test_samples])
+
+
+def test_dataset_train_validation_test_spatial_splits(data_folder: Path, h5py_folder: Path, normalizer: Normalizer):
+    def create_dataset(mode: Mode, validation_folds: frozenset[int], test_folds: frozenset[int]):
+        return LFMCDataset(
+            normalizer=normalizer,
+            data_folder=data_folder,
+            h5py_folder=h5py_folder,
+            h5pys_only=False,
+            mode=mode,
+            split_type=SplitType.SPATIAL,
             validation_folds=validation_folds,
             test_folds=test_folds,
         )

--- a/tests/core/test_eval.py
+++ b/tests/core/test_eval.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+import torch
 from frozenlist import FrozenList
 
 from galileo.data.dataset import (
@@ -15,6 +16,7 @@ from galileo.galileo import Encoder
 from lfmc.core.bands import SPACE_BANDS, SPACE_TIME_BANDS, STATIC_BANDS, TIME_BANDS
 from lfmc.core.const import MeteorologicalSeason, WorldCoverClass
 from lfmc.core.eval import FinetuningConfig, LFMCEval, finetune_and_evaluate
+from lfmc.core.splits import SplitType
 
 
 def test_finetune_and_test(
@@ -121,6 +123,40 @@ def test_finetune_and_evaluate(
     assert "prediction" in df.columns
 
 
+def test_finetune_and_evaluate_spatial_split(
+    tmp_path: Path,
+    normalizer: Normalizer,
+    encoder: Encoder,
+    data_folder: Path,
+    h5py_folder: Path,
+):
+    output_folder = tmp_path / "results"
+    output_folder.mkdir(parents=True, exist_ok=True)
+    results, df = finetune_and_evaluate(
+        normalizer=normalizer,
+        pretrained_model=encoder,
+        data_folder=data_folder,
+        h5py_folder=h5py_folder,
+        output_folder=output_folder,
+        split_type=SplitType.SPATIAL,
+        validation_folds=frozenset([0]),
+        test_folds=frozenset([1]),
+    )
+    assert results is not None
+    assert isinstance(results, dict)
+    assert df is not None
+    assert isinstance(df, pd.DataFrame)
+    assert "all" in results
+    assert "r2_score" in results["all"]
+    assert "baseline" in results
+
+    assert 0 <= df.shape[0] <= len(list(data_folder.glob("*.tif")))
+    assert "latitude" in df.columns
+    assert "longitude" in df.columns
+    assert "label" in df.columns
+    assert "prediction" in df.columns
+
+
 def test_finetune_and_evaluate_state_regions(
     tmp_path: Path,
     normalizer: Normalizer,
@@ -177,6 +213,83 @@ def test_finetune_and_evaluate_state_regions(
     assert "longitude" in df.columns
     assert "label" in df.columns
     assert "prediction" in df.columns
+
+
+def test_checkpoint_saves_correct_epoch(
+    tmp_path: Path,
+    normalizer: Normalizer,
+    encoder: Encoder,
+    data_folder: Path,
+    h5py_folder: Path,
+):
+    output_folder = tmp_path / "finetuned"
+    output_folder.mkdir(parents=True, exist_ok=True)
+    lfmc_eval = LFMCEval(
+        normalizer=normalizer,
+        data_folder=data_folder,
+        h5py_folder=h5py_folder,
+        h5pys_only=False,
+        validation_folds=frozenset([0]),
+        test_folds=frozenset([1]),
+    )
+    finetuning_config = FinetuningConfig(
+        max_epochs=3,
+        weight_decay=0.001,
+        learning_rate=0.001,
+        batch_size=16,
+        patience=100,
+    )
+    lfmc_eval.finetune(
+        pretrained_model=encoder,
+        output_folder=output_folder,
+        finetuning_config=finetuning_config,
+    )
+
+    checkpoint_path = output_folder / "checkpoint.pth"
+    assert checkpoint_path.exists()
+    assert not (output_folder / "checkpoint.pth.tmp").exists()
+
+    checkpoint = torch.load(checkpoint_path)
+    assert checkpoint["epoch"] == 3
+    assert checkpoint["best_model_dict"] is not None
+    assert checkpoint["best_loss"] is not None
+    assert checkpoint["epochs_since_improvement"] >= 0
+
+
+def test_checkpoint_resume_skips_completed_epochs(
+    tmp_path: Path,
+    normalizer: Normalizer,
+    encoder: Encoder,
+    data_folder: Path,
+    h5py_folder: Path,
+):
+    output_folder = tmp_path / "finetuned"
+    output_folder.mkdir(parents=True, exist_ok=True)
+    lfmc_eval = LFMCEval(
+        normalizer=normalizer,
+        data_folder=data_folder,
+        h5py_folder=h5py_folder,
+        h5pys_only=False,
+        validation_folds=frozenset([0]),
+        test_folds=frozenset([1]),
+    )
+
+    # Train for 2 epochs
+    config_2 = FinetuningConfig(max_epochs=2, weight_decay=0.001, learning_rate=0.001, batch_size=16, patience=100)
+    lfmc_eval.finetune(pretrained_model=encoder, output_folder=output_folder, finetuning_config=config_2)
+
+    checkpoint = torch.load(output_folder / "checkpoint.pth")
+    assert checkpoint["epoch"] == 2
+
+    # Simulate preemption: remove the final model so finetune doesn't early-return
+    (output_folder / "finetuned_model.pth").unlink()
+
+    # Resume and train to 5 epochs total
+    config_5 = FinetuningConfig(max_epochs=5, weight_decay=0.001, learning_rate=0.001, batch_size=16, patience=100)
+    lfmc_eval.finetune(pretrained_model=encoder, output_folder=output_folder, finetuning_config=config_5)
+
+    checkpoint = torch.load(output_folder / "checkpoint.pth")
+    assert checkpoint["epoch"] == 5
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_splits.py
+++ b/tests/core/test_splits.py
@@ -1,6 +1,13 @@
 from typing import Sequence
 
-from lfmc.core.splits import DEFAULT_NUM_FOLDS, DEFAULT_TEST_FOLDS, DEFAULT_VALIDATION_FOLDS
+from lfmc.core.const import Column
+from lfmc.core.splits import (
+    DEFAULT_NUM_FOLDS,
+    DEFAULT_TEST_FOLDS,
+    DEFAULT_VALIDATION_FOLDS,
+    SPLIT_TYPE_COLUMN,
+    SplitType,
+)
 
 
 def assert_sets_unique(sets: Sequence[set[float]]):
@@ -15,3 +22,9 @@ def test_default_validation_and_test_folds():
         assert 0 <= fold < DEFAULT_NUM_FOLDS
     for fold in DEFAULT_TEST_FOLDS:
         assert 0 <= fold < DEFAULT_NUM_FOLDS
+
+
+def test_split_type_column_mapping():
+    assert SPLIT_TYPE_COLUMN[SplitType.RANDOM] == Column.SORTING_ID
+    assert SPLIT_TYPE_COLUMN[SplitType.SPATIAL] == Column.SITE_NAME
+    assert set(SPLIT_TYPE_COLUMN.keys()) == set(SplitType)

--- a/tests/main/test_collect_results.py
+++ b/tests/main/test_collect_results.py
@@ -1,0 +1,201 @@
+import json
+from pathlib import Path
+
+from lfmc.main.collect_results import (
+    ExperimentConfig,
+    _normalize_excluded_bands,
+    collect_results,
+    generate_table_1,
+    generate_table_5,
+    generate_table_6,
+    load_experiments,
+)
+
+SAMPLE_RESULTS = {
+    "all": {"rmse": 18.91, "mae": 12.58, "r2_score": 0.72},
+    "baseline": {"rmse": 33.66, "mae": 25.38, "r2_score": 0.11},
+    "Winter": {"rmse": 15.31, "mae": 10.74, "r2_score": 0.77},
+    "Spring": {"rmse": 22.85, "mae": 15.35, "r2_score": 0.69},
+    "Summer": {"rmse": 19.70, "mae": 13.05, "r2_score": 0.67},
+    "Autumn": {"rmse": 12.70, "mae": 9.27, "r2_score": 0.75},
+    "Tree cover": {"rmse": 18.00, "mae": 11.97, "r2_score": 0.68},
+    "Grassland": {"rmse": 20.09, "mae": 13.62, "r2_score": 0.73},
+    "Shrubland": {"rmse": 19.53, "mae": 12.28, "r2_score": 0.74},
+    "Built-up": {"rmse": 16.79, "mae": 11.78, "r2_score": 0.77},
+    "Bare / sparse vegetation": {"rmse": 20.52, "mae": 15.67, "r2_score": 0.79},
+    "elevation_0_500": {"rmse": 18.34, "mae": 11.59, "r2_score": 0.73},
+    "elevation_500_1000": {"rmse": 17.93, "mae": 11.98, "r2_score": 0.77},
+    "elevation_1000_1500": {"rmse": 21.65, "mae": 14.54, "r2_score": 0.73},
+    "elevation_1500_2000": {"rmse": 18.91, "mae": 13.56, "r2_score": 0.75},
+    "elevation_2000_2500": {"rmse": 19.35, "mae": 12.44, "r2_score": 0.61},
+    "elevation_2500_3000": {"rmse": 15.25, "mae": 10.00, "r2_score": 0.54},
+    "elevation_3000_3500": {"rmse": 14.54, "mae": 10.41, "r2_score": 0.32},
+    "high_fire_danger": {"rmse": 19.0, "mae": 12.6, "r2_score": 0.70},
+    "non_high_fire_danger": {"rmse": 18.5, "mae": 12.3, "r2_score": 0.74},
+}
+
+
+def _write_experiment(folder: Path, config: dict, results: dict) -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    with open(folder / "experiment_config.json", "w") as f:
+        json.dump(config, f)
+    with open(folder / "results.json", "w") as f:
+        json.dump(results, f)
+
+
+def _default_config(**overrides) -> dict:
+    config = {
+        "split_type": "random",
+        "load_weights": True,
+        "excluded_bands": "",
+        "output_hw": 32,
+        "output_timesteps": 12,
+        "patch_size": 16,
+        "completed_at": "2026-03-24T00:00:00+00:00",
+    }
+    config.update(overrides)
+    return config
+
+
+def test_normalize_excluded_bands():
+    assert _normalize_excluded_bands("") == ""
+    assert _normalize_excluded_bands("S1") == "S1"
+    assert _normalize_excluded_bands("NDVI,S2_RGB,S2_SWIR") == "NDVI,S2_RGB,S2_SWIR"
+    assert _normalize_excluded_bands("S2_SWIR,NDVI,S2_RGB") == "NDVI,S2_RGB,S2_SWIR"
+
+
+def test_load_experiments(tmp_path: Path):
+    _write_experiment(tmp_path / "exp1", _default_config(), SAMPLE_RESULTS)
+    _write_experiment(tmp_path / "exp2", _default_config(load_weights=False), SAMPLE_RESULTS)
+
+    experiments = load_experiments(tmp_path)
+    assert len(experiments) == 2
+    configs = {exp.config.load_weights for exp in experiments}
+    assert configs == {True, False}
+
+
+def test_load_experiments_skips_missing_results(tmp_path: Path):
+    folder = tmp_path / "incomplete"
+    folder.mkdir()
+    with open(folder / "experiment_config.json", "w") as f:
+        json.dump(_default_config(), f)
+
+    experiments = load_experiments(tmp_path)
+    assert len(experiments) == 0
+
+
+def test_experiment_config_properties():
+    default = ExperimentConfig(
+        split_type="random", load_weights=True, excluded_bands="", output_hw=32, output_timesteps=12, patch_size=16
+    )
+    assert default.is_default_shape
+    assert not default.has_excluded_bands
+
+    non_default = ExperimentConfig(
+        split_type="spatial", load_weights=False, excluded_bands="S1", output_hw=16, output_timesteps=6, patch_size=8
+    )
+    assert not non_default.is_default_shape
+    assert non_default.has_excluded_bands
+
+
+def test_generate_table_1(tmp_path: Path):
+    _write_experiment(tmp_path / "pretrained", _default_config(), SAMPLE_RESULTS)
+    random_results = {**SAMPLE_RESULTS, "all": {"rmse": 23.61, "mae": 16.33, "r2_score": 0.57}}
+    _write_experiment(tmp_path / "random", _default_config(load_weights=False), random_results)
+
+    experiments = load_experiments(tmp_path)
+    table = generate_table_1(experiments, "random")
+
+    assert "Pretrained" in table
+    assert "Random initialized" in table
+    assert "Monthly predictions" in table
+    assert "18.91" in table
+    assert "23.61" in table
+    assert "33.66" in table
+
+
+def test_generate_table_5(tmp_path: Path):
+    _write_experiment(tmp_path / "default", _default_config(), SAMPLE_RESULTS)
+    small_results = {**SAMPLE_RESULTS, "all": {"rmse": 20.25, "mae": 13.46, "r2_score": 0.68}}
+    _write_experiment(
+        tmp_path / "small",
+        _default_config(output_hw=1, output_timesteps=12, patch_size=1),
+        small_results,
+    )
+
+    experiments = load_experiments(tmp_path)
+    table = generate_table_5(experiments, "random")
+
+    assert "| 32 | 12 | 16 |" in table
+    assert "| 1 | 12 | 1 |" in table
+    assert "20.25" in table
+
+
+def test_generate_table_6(tmp_path: Path):
+    _write_experiment(tmp_path / "none_pretrained", _default_config(), SAMPLE_RESULTS)
+    _write_experiment(tmp_path / "none_random", _default_config(load_weights=False), SAMPLE_RESULTS)
+    s1_results = {**SAMPLE_RESULTS, "all": {"rmse": 18.82, "mae": 13.10, "r2_score": 0.72}}
+    _write_experiment(tmp_path / "s1_pretrained", _default_config(excluded_bands="S1"), s1_results)
+
+    experiments = load_experiments(tmp_path)
+    table = generate_table_6(experiments, "random")
+
+    assert "None" in table
+    assert "S1" in table
+    assert "18.82" in table
+
+
+def test_collect_results_both_splits(tmp_path: Path):
+    _write_experiment(tmp_path / "random_pretrained", _default_config(), SAMPLE_RESULTS)
+    _write_experiment(tmp_path / "spatial_pretrained", _default_config(split_type="spatial"), SAMPLE_RESULTS)
+
+    output = collect_results(tmp_path)
+
+    assert "# Results (random vs spatial)" in output
+    assert "## Table 1: Overall Results" in output
+    assert "## Table 2: Season Breakdown" in output
+    assert "## Table 3: Land Cover Breakdown" in output
+    assert "## Table 4: Elevation Breakdown" in output
+    assert "## Table 5: Shape Ablations" in output
+    assert "## Table 6: Data Ablations" in output
+    assert "Random RMSE" in output
+    assert "Spatial RMSE" in output
+
+
+def test_load_experiments_deduplicates_by_completed_at(tmp_path: Path):
+    old_results = {**SAMPLE_RESULTS, "all": {"rmse": 99.0, "mae": 99.0, "r2_score": 0.01}}
+    _write_experiment(
+        tmp_path / "old_run",
+        _default_config(completed_at="2026-03-20T00:00:00+00:00"),
+        old_results,
+    )
+    _write_experiment(
+        tmp_path / "new_run",
+        _default_config(completed_at="2026-03-24T12:00:00+00:00"),
+        SAMPLE_RESULTS,
+    )
+
+    experiments = load_experiments(tmp_path)
+    assert len(experiments) == 1
+    assert experiments[0].results["all"]["rmse"] == 18.91
+    assert experiments[0].path == tmp_path / "new_run"
+
+
+def test_load_experiments_dedup_without_completed_at(tmp_path: Path):
+    """Without completed_at, first experiment found wins (both have empty string)."""
+    old_results = {**SAMPLE_RESULTS, "all": {"rmse": 99.0, "mae": 99.0, "r2_score": 0.01}}
+    old_config = _default_config()
+    del old_config["completed_at"]
+    new_config = _default_config()
+    del new_config["completed_at"]
+
+    _write_experiment(tmp_path / "aaa", old_config, old_results)
+    _write_experiment(tmp_path / "zzz", new_config, SAMPLE_RESULTS)
+
+    experiments = load_experiments(tmp_path)
+    assert len(experiments) == 1
+
+
+def test_collect_results_empty_dir(tmp_path: Path):
+    output = collect_results(tmp_path)
+    assert output == "No experiments found."


### PR DESCRIPTION
- Add spatial (site-name-based) split support alongside the existing random split
- Fix checkpoint resume logic and add Beaker experiment orchestration for running all 38 paper experiments
- Include generated results tables comparing random vs spatial splits across all ablations